### PR TITLE
Fix return limits for a product

### DIFF
--- a/app/models/billing/limiter.rb
+++ b/app/models/billing/limiter.rb
@@ -39,7 +39,7 @@ class Billing::Limiter
   def limits_for(action, model)
     # Collect any relevant limits from all active products.
     current_products.map do |product|
-      limits = product.respond_to?(:limits) ? (product.limits & [model.name.underscore.pluralize] || {}) : {}
+      limits = product.respond_to?(:limits) ? (product.limits[model.name.underscore.pluralize] || {}) : {}
       limits.each do |action, limit|
         limit["product_id"] = product.id
       end


### PR DESCRIPTION
In my testing `product.limits` will return a hash so we need to access the limits by using the model name to fetch the hash value