### PR TITLE
Fix Issue with Base Limiter Usage Checking

### DIFF
--- a/app/models/concerns/billing/limiter/base.rb
+++ b/app/models/concerns/billing/limiter/base.rb
@@ -85,7 +85,7 @@ module Billing::Limiter::Base
   end
 
   def usage_for(action, model, duration, interval)
-    @parent.current_billing_usage_trackers.detect do |tracker|
+    @parent.billing_usage_trackers.current.detect do |tracker|
       tracker.duration == duration && tracker.interval == interval
     end&.usage&.dig(model.name, action.to_s.verb.conjugate(tense: :past))
   end


### PR DESCRIPTION
This PR fixes a missed refactoring of the limit based usage trackers.

The checking of usage was still using `current_billing_usage_trackers` instead of `billing_usage_trackers.current` off of the parent within the concern.
