### PR TITLE
Fix duplicate cycles

### DIFF
--- a/app/models/billing/usage/tracker.rb
+++ b/app/models/billing/usage/tracker.rb
@@ -10,7 +10,12 @@ class Billing::Usage::Tracker < BulletTrain::Billing::Usage.base_class.constanti
 
   def self.cycles
     # e.g. [[1, "day"], [5, "minutes"]]
-    Billing::Product.all.map(&:limits).compact.flatten.map(&:values).flatten.map(&:values).flatten.select { |limit| limit.key?("duration") }.map { |limit| [limit["duration"], limit["interval"]] }
+    Billing::Product.all
+      .map(&:limits).compact.flatten
+      .map(&:values).flatten # get the limits without the relationships
+      .map(&:values).flatten # get the limites without the verbs
+      .select { |limit| limit.key?("duration") }.map { |limit| [limit["duration"], limit["interval"]] }
+      .uniq
   end
 
   def track(action, model, count)


### PR DESCRIPTION
This PR fixes an issue where we would get duplicate current usage trackers.

This was caused by having multiple verbs with the same limit cycles on them.

```
# products.yml

basic:
  limits:
    foos:
      count: 10
      enforcement: hard
      interval: month
      duration: 1
    bars:
      count: 10
      enforcement: hard
      interval: month
      duration: 1
```

The `Billing::Usage::Tracker.cycles` would return duplicate 1 month intervals and that would cause `HasTrackers.billing_usage_trackers.current` to return duplicate trackers for the single cycle.

Closes #12
