### PR TITLE
Highest limit wins

### DIFF
--- a/app/models/concerns/billing/limiter/base.rb
+++ b/app/models/concerns/billing/limiter/base.rb
@@ -92,7 +92,7 @@ module Billing::Limiter::Base
     # most permissive limit wins out
     limits = limits_for(action, model, enforcement: enforcement)
 
-    if limits.any?{|limit| limit.has_key?("count") && limit["count"].nil? }
+    if limits.any? { |limit| limit.has_key?("count") && limit["count"].nil? }
       # a nil count represents unlimited
       []
     else

--- a/test/models/billing/limiter_test.rb
+++ b/test/models/billing/limiter_test.rb
@@ -20,9 +20,9 @@ class Billing::LimiterTest < ActiveSupport::TestCase
       [
         OpenStruct.new(id: "basic",
           limits: {"blahs" => {"create" => {"count" => 2,
-                                          "enforcement" => "hard",
-                                          "duration" => 1,
-                                          "interval" => "month"}}}),
+                                            "enforcement" => "hard",
+                                            "duration" => 1,
+                                            "interval" => "month"}}}),
         OpenStruct.new(id: "upgrade",
           limits: {"blahs" => {"create" => {"count" => 3,
                                             "enforcement" => "hard",
@@ -32,7 +32,7 @@ class Billing::LimiterTest < ActiveSupport::TestCase
     end
   end
 
-  describe "with a stubbed product catalog" do
+  describe "with a stubbed product catalog of a single limit" do
     let(:all_products) { limiter.current_products }
     let(:limiter) { TestLimiter.new(team) }
     let(:team) { FactoryBot.create(:team) }
@@ -90,7 +90,6 @@ class Billing::LimiterTest < ActiveSupport::TestCase
             end
           end
         end
-
 
         describe "when we are surpassing the higher limit" do
           it "returns the broken limit" do

--- a/test/models/billing/limiter_test.rb
+++ b/test/models/billing/limiter_test.rb
@@ -32,6 +32,25 @@ class Billing::LimiterTest < ActiveSupport::TestCase
     end
   end
 
+  class MultipleProductWithUnlimitedTestLimiter
+    include Billing::Limiter::Base
+
+    def current_products
+      [
+        OpenStruct.new(id: "basic",
+          limits: {"blahs" => {"create" => {"count" => 2,
+                                            "enforcement" => "hard",
+                                            "duration" => 1,
+                                            "interval" => "month"}}}),
+        OpenStruct.new(id: "upgrade",
+          limits: {"blahs" => {"create" => {"count" => nil,
+                                            "enforcement" => "hard",
+                                            "duration" => 1,
+                                            "interval" => "month"}}})
+      ]
+    end
+  end
+
   describe "with a stubbed product catalog of a single limit" do
     let(:all_products) { limiter.current_products }
     let(:limiter) { TestLimiter.new(team) }
@@ -106,6 +125,23 @@ class Billing::LimiterTest < ActiveSupport::TestCase
                          "interval" => "month",
                          "product_id" => "upgrade"}}
               ]
+            end
+          end
+        end
+
+        describe "one limit has a nil count (unlimited)" do
+          let(:all_products) { limiter.current_products }
+          let(:limiter) { MultipleProductWithUnlimitedTestLimiter.new(team) }
+          let(:team) { FactoryBot.create(:team) }
+
+          describe "when we are surpassing the lower limit by a lot" do
+            it "returns an empty array for no broken hard limits" do
+              tracker = FactoryBot.create(:tracker, team: team, interval: "month", duration: 1)
+              FactoryBot.create(:count, tracker: tracker, action: "created", name: "Blah", count: 5)
+
+              Billing::Usage::ProductCatalog.stub(:all_products, all_products) do
+                assert_empty limiter.broken_hard_limits_for(:create, "Blah")
+              end
             end
           end
         end


### PR DESCRIPTION
If there are multiple `included_prices` limiting the same underlying object, lets have the highest `count` win out.

The current behavior is that the lowest `count` will be enough to break a limit, even though we have another `included_price` with a higher `count`.