### PR TITLE
Fix bug around unspecified limits - `exhausted_usage_for`

### DIFF
--- a/app/models/concerns/billing/limiter/base.rb
+++ b/app/models/concerns/billing/limiter/base.rb
@@ -72,14 +72,14 @@ module Billing::Limiter::Base
     limit = enforced_limit_for(action, model, enforcement: enforcement)
 
     [].tap do |exceeded_limits|
-      if (exhausted_usage = exhausted_usage_for(limit, action, model, count: count))
+      if limit && (exhausted_usage = exhausted_usage_for(limit, action, model, count: count))
         # We notate the action here because `:create` ends up aggregating broken limits for both `:create` and `:have`.
-        exceeded_limits << {action: action, usage: exhausted_usage, limit: limit}
+        exceeded_limits.concat({action: action, usage: exhausted_usage, limit: limit})
       end
 
       # If we're checking whether we can create something, we also need to check if it can exist.
       if action == :create
-        exceeded_limits << broken_limits_for(:have, model, enforcement: enforcement, count: count)
+        exceeded_limits.concat(broken_limits_for(:have, model, enforcement: enforcement, count: count))
       end
     end
   end

--- a/test/models/billing/limiter_test.rb
+++ b/test/models/billing/limiter_test.rb
@@ -57,6 +57,14 @@ class Billing::LimiterTest < ActiveSupport::TestCase
     let(:team) { FactoryBot.create(:team) }
 
     describe "#broken_hard_limits_for" do
+      describe "asking for limits for something that is not limited" do
+        it "returns an empty array for no broken hard limits" do
+          Billing::Usage::ProductCatalog.stub(:all_products, all_products) do
+            assert_empty limiter.broken_hard_limits_for(:create, "SOMETHING WE DO NOT LIMIT")
+          end
+        end
+      end
+
       it "returns an empty array for no broken hard limits" do
         Billing::Usage::ProductCatalog.stub(:all_products, all_products) do
           assert_empty limiter.broken_hard_limits_for(:create, "Blah")


### PR DESCRIPTION
The last commit `857c422257c840a0660ed3a088613c354ee80554` introduced a bug in the `exhausted_usage_for` method.

If there is no specified limit found for a given resource, this line will be `nil`:
```
limit = enforced_limit_for(action, model, enforcement: enforcement)
```

Which will then cause this line to error out, `exhausted_usage = exhausted_usage_for(limit, action, model, count: count))`. The specific error is `undefined method '[]' for nil:NilClass`, because we call this line, `limit["count"].nil?`. Cannot access attrs on nil