### PR TITLE
Fix issue related to have action in broken_limits_for

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
       unicode-emoji
       valid_email
       xxhash
-    bullet_train-billing (1.0.7)
+    bullet_train-billing (1.0.9)
       bullet_train
       rails (>= 6.0)
     bullet_train-fields (1.2.27)

--- a/app/models/billing/usage/tracker.rb
+++ b/app/models/billing/usage/tracker.rb
@@ -2,6 +2,9 @@ class Billing::Usage::Tracker < BulletTrain::Billing::Usage.base_class.constanti
   # e.g. `belongs_to :team`
   belongs_to BulletTrain::Billing::Usage.parent_association
 
+  # just for specs
+  scope :billable, -> { all }
+
   has_many :counts, dependent: :destroy do
     def for(action, model)
       order(created_at: :desc).find_by(action: action, name: model.to_s)

--- a/app/models/concerns/billing/limiter/base.rb
+++ b/app/models/concerns/billing/limiter/base.rb
@@ -72,7 +72,7 @@ module Billing::Limiter::Base
     limit = enforced_limit_for(action, model, enforcement: enforcement)
 
     [].tap do |exceeded_limits|
-      if limit && (exhausted_usage = exhausted_usage_for(limit, action, model, count: count))
+      if limit.present? && (exhausted_usage = exhausted_usage_for(limit, action, model, count: count))
         # We notate the action here because `:create` ends up aggregating broken limits for both `:create` and `:have`.
         exceeded_limits.push({action: action, usage: exhausted_usage, limit: limit})
       end

--- a/app/models/concerns/billing/limiter/base.rb
+++ b/app/models/concerns/billing/limiter/base.rb
@@ -74,7 +74,7 @@ module Billing::Limiter::Base
     [].tap do |exceeded_limits|
       if limit && (exhausted_usage = exhausted_usage_for(limit, action, model, count: count))
         # We notate the action here because `:create` ends up aggregating broken limits for both `:create` and `:have`.
-        exceeded_limits.concat({action: action, usage: exhausted_usage, limit: limit})
+        exceeded_limits.push({action: action, usage: exhausted_usage, limit: limit})
       end
 
       # If we're checking whether we can create something, we also need to check if it can exist.

--- a/test/models/billing/limiter_test.rb
+++ b/test/models/billing/limiter_test.rb
@@ -86,6 +86,24 @@ class Billing::LimiterTest < ActiveSupport::TestCase
                      "product_id" => "basic"}}
           ]
         end
+
+        describe "have" do
+          it "returns the broken limits if they are broken" do
+            tracker = FactoryBot.create(:tracker, team: team, interval: "month", duration: 1)
+            FactoryBot.create(:count, tracker: tracker, action: "created", name: "Blah", count: 2)
+
+            Billing::Usage::ProductCatalog.stub(:all_products, all_products) do
+              assert_equal limiter.broken_hard_limits_for(:have, "Blah"), [
+                {action: :have,
+                 usage: 2,
+                 limit: {"count" => 2,
+                         "enforcement" => "hard",
+                         "duration" => 1,
+                         "interval" => "month",
+                         "product_id" => "basic"}}
+              ]
+            end
+        end
       end
 
       it "returns the broken limits if they could be broken by the count" do

--- a/test/models/billing/limiter_test.rb
+++ b/test/models/billing/limiter_test.rb
@@ -98,35 +98,35 @@ class Billing::LimiterTest < ActiveSupport::TestCase
                      "product_id" => "basic"}}
           ]
         end
+      end
 
-        describe "have" do
-          let(:all_products) { limiter.current_products }
-          let(:limiter) { TestForHaveLimiter.new(team) }
-          let(:team) { FactoryBot.create(:team) }
+      describe "have" do
+        let(:all_products) { limiter.current_products }
+        let(:limiter) { TestForHaveLimiter.new(team) }
+        let(:team) { FactoryBot.create(:team) }
 
-          describe "can have" do
-            it "returns an empty array for no broken hard limits" do
-              Billing::Usage::ProductCatalog.stub(:all_products, all_products) do
-                assert_empty limiter.broken_hard_limits_for(:have, "Billing::Usage::Tracker")
-              end
+        describe "can have" do
+          it "returns an empty array for no broken hard limits" do
+            Billing::Usage::ProductCatalog.stub(:all_products, all_products) do
+              assert_empty limiter.broken_hard_limits_for(:have, "Billing::Usage::Tracker")
             end
           end
+        end
 
-          describe "cannot have" do
-            it "returns the broken limits" do
-              tracker = FactoryBot.create(:tracker, team: team, interval: "month", duration: 1)
+        describe "cannot have" do
+          it "returns the broken limits" do
+            tracker = FactoryBot.create(:tracker, team: team, interval: "month", duration: 1)
 
-              Billing::Usage::ProductCatalog.stub(:all_products, all_products) do
-                assert_equal limiter.broken_hard_limits_for(:have, "Billing::Usage::Tracker"), [
-                  {action: :have,
-                   usage: 2,
-                   limit: {"count" => 1,
-                           "enforcement" => "hard",
-                           "duration" => 1,
-                           "interval" => "month",
-                           "product_id" => "basic"}}
-                ]
-              end
+            Billing::Usage::ProductCatalog.stub(:all_products, all_products) do
+              assert_equal limiter.broken_hard_limits_for(:have, "Billing::Usage::Tracker"), [
+                {action: :have,
+                  usage: 2,
+                  limit: {"count" => 1,
+                          "enforcement" => "hard",
+                          "duration" => 1,
+                          "interval" => "month",
+                          "product_id" => "basic"}}
+              ]
             end
           end
         end

--- a/test/models/billing/limiter_test.rb
+++ b/test/models/billing/limiter_test.rb
@@ -19,12 +19,11 @@ class Billing::LimiterTest < ActiveSupport::TestCase
     def current_products
       [OpenStruct.new(id: "basic",
         limits: {"billing_usage_trackers" => {"have" => {"count" => 1,
-                                          "enforcement" => "hard",
-                                          "duration" => 1,
-                                          "interval" => "month"}}})]
+                                                         "enforcement" => "hard",
+                                                         "duration" => 1,
+                                                         "interval" => "month"}}})]
     end
   end
-
 
   class MultipleProductTestLimiter
     include Billing::Limiter::Base
@@ -121,12 +120,12 @@ class Billing::LimiterTest < ActiveSupport::TestCase
             Billing::Usage::ProductCatalog.stub(:all_products, all_products) do
               assert_equal limiter.broken_hard_limits_for(:have, "Billing::Usage::Tracker"), [
                 {action: :have,
-                  usage: 1,
-                  limit: {"count" => 1,
-                          "enforcement" => "hard",
-                          "duration" => 1,
-                          "interval" => "month",
-                          "product_id" => "basic"}}
+                 usage: 1,
+                 limit: {"count" => 1,
+                         "enforcement" => "hard",
+                         "duration" => 1,
+                         "interval" => "month",
+                         "product_id" => "basic"}}
               ]
             end
           end

--- a/test/models/billing/limiter_test.rb
+++ b/test/models/billing/limiter_test.rb
@@ -115,7 +115,7 @@ class Billing::LimiterTest < ActiveSupport::TestCase
 
         describe "cannot have" do
           it "returns the broken limits" do
-            tracker = FactoryBot.create(:tracker, team: team, interval: "month", duration: 1)
+            FactoryBot.create(:tracker, team: team, interval: "month", duration: 1)
 
             Billing::Usage::ProductCatalog.stub(:all_products, all_products) do
               assert_equal limiter.broken_hard_limits_for(:have, "Billing::Usage::Tracker"), [

--- a/test/models/billing/limiter_test.rb
+++ b/test/models/billing/limiter_test.rb
@@ -13,6 +13,19 @@ class Billing::LimiterTest < ActiveSupport::TestCase
     end
   end
 
+  class TestForHaveLimiter
+    include Billing::Limiter::Base
+
+    def current_products
+      [OpenStruct.new(id: "basic",
+        limits: {"billing_usage_trackers" => {"have" => {"count" => 1,
+                                          "enforcement" => "hard",
+                                          "duration" => 1,
+                                          "interval" => "month"}}})]
+    end
+  end
+
+
   class MultipleProductTestLimiter
     include Billing::Limiter::Base
 
@@ -72,8 +85,7 @@ class Billing::LimiterTest < ActiveSupport::TestCase
       end
 
       it "returns the broken limits if they are broken" do
-        tracker = FactoryBot.create(:tracker, team: team, interval: "month", duration: 1)
-        FactoryBot.create(:count, tracker: tracker, action: "created", name: "Blah", count: 2)
+        FactoryBot.create(:tracker, team: team, interval: "month", duration: 1)
 
         Billing::Usage::ProductCatalog.stub(:all_products, all_products) do
           assert_equal limiter.broken_hard_limits_for(:create, "Blah"), [
@@ -88,35 +100,35 @@ class Billing::LimiterTest < ActiveSupport::TestCase
         end
 
         describe "have" do
-          it "returns the broken limits if they are broken" do
-            tracker = FactoryBot.create(:tracker, team: team, interval: "month", duration: 1)
-            FactoryBot.create(:count, tracker: tracker, action: "created", name: "Blah", count: 2)
+          let(:all_products) { limiter.current_products }
+          let(:limiter) { TestForHaveLimiter.new(team) }
+          let(:team) { FactoryBot.create(:team) }
 
-            Billing::Usage::ProductCatalog.stub(:all_products, all_products) do
-              assert_equal limiter.broken_hard_limits_for(:have, "Blah"), [
-                {action: :have,
-                 usage: 2,
-                 limit: {"count" => 2,
-                         "enforcement" => "hard",
-                         "duration" => 1,
-                         "interval" => "month",
-                         "product_id" => "basic"}}
-              ]
+          describe "can have" do
+            it "returns an empty array for no broken hard limits" do
+              Billing::Usage::ProductCatalog.stub(:all_products, all_products) do
+                assert_empty limiter.broken_hard_limits_for(:have, "Billing::Usage::Tracker")
+              end
             end
-        end
-      end
+          end
 
-      it "returns the broken limits if they could be broken by the count" do
-        Billing::Usage::ProductCatalog.stub(:all_products, all_products) do
-          assert_equal limiter.broken_hard_limits_for(:create, "Blah", count: 3), [
-            {action: :create,
-             usage: 0,
-             limit: {"count" => 2,
-                     "enforcement" => "hard",
-                     "duration" => 1,
-                     "interval" => "month",
-                     "product_id" => "basic"}}
-          ]
+          describe "cannot have" do
+            it "returns the broken limits" do
+              tracker = FactoryBot.create(:tracker, team: team, interval: "month", duration: 1)
+
+              Billing::Usage::ProductCatalog.stub(:all_products, all_products) do
+                assert_equal limiter.broken_hard_limits_for(:have, "Billing::Usage::Tracker"), [
+                  {action: :have,
+                   usage: 2,
+                   limit: {"count" => 1,
+                           "enforcement" => "hard",
+                           "duration" => 1,
+                           "interval" => "month",
+                           "product_id" => "basic"}}
+                ]
+              end
+            end
+          end
         end
       end
 

--- a/test/models/billing/limiter_test.rb
+++ b/test/models/billing/limiter_test.rb
@@ -85,7 +85,8 @@ class Billing::LimiterTest < ActiveSupport::TestCase
       end
 
       it "returns the broken limits if they are broken" do
-        FactoryBot.create(:tracker, team: team, interval: "month", duration: 1)
+        tracker = FactoryBot.create(:tracker, team: team, interval: "month", duration: 1)
+        FactoryBot.create(:count, tracker: tracker, action: "created", name: "Blah", count: 2)
 
         Billing::Usage::ProductCatalog.stub(:all_products, all_products) do
           assert_equal limiter.broken_hard_limits_for(:create, "Blah"), [
@@ -120,7 +121,7 @@ class Billing::LimiterTest < ActiveSupport::TestCase
             Billing::Usage::ProductCatalog.stub(:all_products, all_products) do
               assert_equal limiter.broken_hard_limits_for(:have, "Billing::Usage::Tracker"), [
                 {action: :have,
-                  usage: 2,
+                  usage: 1,
                   limit: {"count" => 1,
                           "enforcement" => "hard",
                           "duration" => 1,


### PR DESCRIPTION
We are trying to concat a hash, which leads to an error. Lets use push instead.

Specs were erroneously passing on CI due to a commented out line. Jag is going to fix that later. For now, the specs pass locally