### PR TITLE
Do not Fail hard if unlinked Billing::Subscriptions::IncludedPrice

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   ruby: circleci/ruby@0.1.2
-  browser-tools: circleci/browser-tools@1.4.1
+  browser-tools: circleci/browser-tools@1.4.6
   jq: circleci/jq@2.2.0
 aliases:
   - &restore_bundler_cache
@@ -105,11 +105,6 @@ jobs:
       - browser-tools/install-browser-tools:
           firefox-version: 108.0.1
 
-      # TODO: This is a workaround to get `git clone` working, but it shouldn't be here.
-      # https://github.com/CircleCI-Public/browser-tools-orb/issues/62
-      - run:
-          command: rm LICENSE.chromedriver
-
       - run: ../../bin/checkout-and-link-starter-repo
       - run: ../../bin/checkout-and-link-dependencies
 
@@ -168,11 +163,6 @@ jobs:
           path: ~/project
       - browser-tools/install-browser-tools:
           firefox-version: 108.0.1
-
-      # TODO: This is a workaround to get `git clone` working, but it shouldn't be here.
-      # https://github.com/CircleCI-Public/browser-tools-orb/issues/62
-      - run:
-          command: rm LICENSE.chromedriver
 
       - run: ../../bin/checkout-and-link-starter-repo
       - run: ../../bin/checkout-and-link-dependencies

--- a/app/models/billing/usage/product_catalog.rb
+++ b/app/models/billing/usage/product_catalog.rb
@@ -8,7 +8,7 @@ class Billing::Usage::ProductCatalog
   end
 
   def current_products
-    products = parent.team.billing_subscriptions.active.map(&:included_prices).flatten.map(&:price).map(&:product)
+    products = parent.team.billing_subscriptions.active.map(&:included_prices).flatten.map(&:price).compact.map(&:product)
     products.any? ? products : free_products
   end
 


### PR DESCRIPTION
Imagine that somehow, someone gets assigned an `Billing::Subscriptions::IncludedPrice#price_id` that is not linked to a price in the `products.yml`.

If this happens, any reference or call to `Billing::Usage::ProductCatalog` will blow up.

Instead, we should ignore the `IncludedPrice` altogether since, we do not have any limits configured for it. (since it is not in products.yml)

To simulate this, go into your console and update one of your `team.current_billing_subscription.included_prices` to a `price_id` not in the `products.yml`. Various calls to the `Billing::Usage::ProductCatalog.current_products` for the workspace will blow up with:

```
[85][12:06:44](deve)> Billing::Usage::ProductCatalog.new(Workspace.last).current_products

/Users/nickphillips/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/bullet_train-billing-usage-1.0.13/app/models/billing/usage/product_catalog.rb:11:in `map': undefined method `product' for nil:NilClass (NoMethodError)
```